### PR TITLE
Async api execution

### DIFF
--- a/android/src/main/kotlin/com/morphingcoffee/snooper_android/BackgroundMethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/morphingcoffee/snooper_android/BackgroundMethodCallHandlerImpl.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import androidx.annotation.NonNull
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.*
 import java.io.ByteArrayOutputStream
 import java.security.cert.CertificateException
 import java.security.cert.CertificateFactory
@@ -26,19 +27,24 @@ import java.security.cert.X509Certificate
 class BackgroundMethodCallHandlerImpl(private val context: Context) :
     MethodChannel.MethodCallHandler {
 
+    // Coroutine scope for executing tasks asynchronously, to avoid blocking current (background) thread
+    private val scope = CoroutineScope(Dispatchers.Default)
+
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
-        when (call.method) {
-            "getPackagesSimple" -> {
-                getPackagesSimple(result)
-            }
-            "getPackagesDetailed" -> {
-                getPackagesDetailed(result)
-            }
-            "getSensors" -> {
-                getSensors(result)
-            }
-            else -> {
-                result.notImplemented()
+        scope.launch {
+            when (call.method) {
+                "getPackagesSimple" -> {
+                    getPackagesSimple(result)
+                }
+                "getPackagesDetailed" -> {
+                    getPackagesDetailed(result)
+                }
+                "getSensors" -> {
+                    getSensors(result)
+                }
+                else -> {
+                    result.notImplemented()
+                }
             }
         }
     }

--- a/android/src/main/kotlin/com/morphingcoffee/snooper_android/BackgroundMethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/morphingcoffee/snooper_android/BackgroundMethodCallHandlerImpl.kt
@@ -78,6 +78,11 @@ class BackgroundMethodCallHandlerImpl(private val context: Context) :
 
     //region detailed package retrieval impl
 
+    /**
+     * The package metadata (e.g. icon) fetching is not parallelized in this impl because running
+     * those tasks asynchronously resulted in *intermittent* binder errors, such as:
+     * `E/JavaBinder: !!! FAILED BINDER TRANSACTION !!!  (parcel size = 168)`
+     */
     private fun getPackagesDetailed(@NonNull result: MethodChannel.Result) {
         val packageInfoMaps = mutableListOf<Map<String, Any?>>()
         val pm: PackageManager = context.packageManager


### PR DESCRIPTION
Made `SnooperAndroid` APIs run without blocking each other:

- Instead of blocking the background thread dedicated by Flutter until they're finished, API calls now execute asynchronously via Kotlin coroutines